### PR TITLE
Implemented `Div<Self> for Angle`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radians"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 description = "A crate for storing angles"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ impl<F: Float + fmt::Debug, U: Unit<F>> fmt::Debug for Wrap<F, U> {
 impl<F: Float, U: Unit<F>> Wrap<F, U> {
     /// Zero angle, additive identity.
     pub const ZERO: Self = Self(Angle::ZERO);
-    /// Half turn around a circle. Equal to π/2 radians or 90°.
+    /// Quarter turn around a circle. Equal to π/2 radians or 90°.
     pub const QUARTER_TURN: Self = Self(Angle::QUARTER_TURN);
     /// Half turn around a circle. Equal to π radians or 180°.
     pub const HALF_TURN: Self = Self(Angle::HALF_TURN);
@@ -350,6 +350,13 @@ macro_rules! impl_ops {
             #[inline]
             fn div_assign(&mut self, rhs: F) {
                 *self = *self / rhs;
+            }
+        }
+        impl<F: Float, U: Unit<F>> Div<Self> for $ang<F, U> {
+            type Output = F;
+            #[inline]
+            fn div(self, rhs: Self) -> F {
+                self.val() / rhs.val()
             }
         }
     };
@@ -630,6 +637,8 @@ mod tests {
         let mut val = Rad64::FULL_TURN;
         val /= 3.0;
         assert_epsilon!(val.val(), PI * 2.0 / 3.0);
+
+        assert_eq!(Rad64::FULL_TURN / Rad64::QUARTER_TURN, 4.0);
     }
 
     #[test]


### PR DESCRIPTION
I'm using this crate in a private project and for better ergonomics would like the ability to divide one angle by another, resulting in a scalar. This PR implements `Div<Self> for Angle<F, U>`, a small test and fixes a small unrelated typo in the doc for `Wrap`.
Ideally one would like to implement `Div<impl Into<Angle<F, U>>> for Angle<F, U>` instead but that is incompatible with the existing `Div<F> for Angle<F, U>`. I guess we have to wait for trait specialization to be available for this to work.